### PR TITLE
Improving switcher

### DIFF
--- a/Monopoly/Assets/Scenes/Board.unity
+++ b/Monopoly/Assets/Scenes/Board.unity
@@ -518,6 +518,14 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 71957288}
   m_CullTransparentMesh: 0
+--- !u!222 &152673654
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476210254}
+  m_CullTransparentMesh: 0
 --- !u!1001 &169147643
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -779,254 +787,6 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 172349731}
   m_LocalRotation: {x: 0.7071068, y: -0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -0.018, y: -0.039, z: -0.201}
-  m_LocalScale: {x: 0.05, y: 0.15000004, z: 0.050000016}
-  m_Children: []
-  m_Father: {fileID: 358942523}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!136 &172349733
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172349731}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
---- !u!33 &172349734
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172349731}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &175110209
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 175110210}
-  - component: {fileID: 175110212}
-  - component: {fileID: 175110211}
-  m_Layer: 5
-  m_Name: NextPlayerLabel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &175110210
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 175110209}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1369408717}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -25.14502, y: -12.5}
-  m_SizeDelta: {x: 41.43, y: 25}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &175110211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 175110209}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 1
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Czynsz
---- !u!222 &152673654
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 152673651}
-  m_CullTransparentMesh: 0
---- !u!1001 &169147643
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1710159244}
-    m_Modifications:
-    - target: {fileID: 7101247496055823439, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_Name
-      value: Tile3
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.67
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.7126164
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.65999997
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalScale.x
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7597546480822302693, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: e873894e7da24314a8a2fa81bb142225, type: 2}
-    - target: {fileID: 1753582909658680310, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 1753582909658680310, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 1753582909658680310, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 8120569743082065346, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-        type: 3}
-      propertyPath: Id
-      value: 3
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1eaa9ba072c40bc479f00bff6f61fcc1, type: 3}
---- !u!1 &172349731
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 172349732}
-  - component: {fileID: 172349734}
-  - component: {fileID: 172349733}
-  m_Layer: 0
-  m_Name: Cylinder
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &172349732
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 172349731}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0.012, y: -0.039, z: -0.163}
   m_LocalScale: {x: 0.05, y: 0.15000004, z: 0.050000016}
   m_Children: []
@@ -1105,7 +865,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
@@ -1856,6 +1615,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Cat
       objectReference: {fileID: 0}
+    - target: {fileID: 100006, guid: 756b0c574f380324a85262e736c0418b, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 400006, guid: 756b0c574f380324a85262e736c0418b, type: 3}
       propertyPath: m_LocalPosition.x
       value: -15.79
@@ -1867,10 +1630,6 @@ PrefabInstance:
     - target: {fileID: 400006, guid: 756b0c574f380324a85262e736c0418b, type: 3}
       propertyPath: m_LocalPosition.z
       value: -18.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 100006, guid: 756b0c574f380324a85262e736c0418b, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400006, guid: 756b0c574f380324a85262e736c0418b, type: 3}
       propertyPath: m_LocalRotation.x
@@ -2051,22 +1810,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1700883501}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &358942525
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 358942518}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fba2329051a959b43bba66afacb15589, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  ownedProperties: []
-  pawn: {fileID: 358942519}
-  dice: {fileID: 28973860}
-  playerName: 
 --- !u!1001 &360213696
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2400,6 +2143,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1eaa9ba072c40bc479f00bff6f61fcc1, type: 3}
+--- !u!1 &476210254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 476210255}
+  - component: {fileID: 152673654}
+  m_Layer: 0
+  m_Name: Recovery GameObject (152673654)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &476210255
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476210254}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &483941406
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3640,13 +3414,13 @@ PrefabInstance:
       propertyPath: m_Name
       value: Teapot
       objectReference: {fileID: 0}
-    - target: {fileID: 456816, guid: dadabfb7666c71040b774315c71951ea, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -17.31
-      objectReference: {fileID: 0}
     - target: {fileID: 189154, guid: dadabfb7666c71040b774315c71951ea, type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 456816, guid: dadabfb7666c71040b774315c71951ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -17.31
       objectReference: {fileID: 0}
     - target: {fileID: 456816, guid: dadabfb7666c71040b774315c71951ea, type: 3}
       propertyPath: m_LocalPosition.y
@@ -4506,73 +4280,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1eaa9ba072c40bc479f00bff6f61fcc1, type: 3}
---- !u!1 &899731587
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 899731588}
-  - component: {fileID: 899731591}
-  - component: {fileID: 899731590}
-  - component: {fileID: 899731589}
-  m_Layer: 0
-  m_Name: Ground
-  m_TagString: Ground
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &899731588
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 899731587}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0.105, y: 0.49, z: 0.037}
-  m_LocalScale: {x: 0.025, y: 2, z: 2}
-  m_Children: []
-  m_Father: {fileID: 286772865}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!114 &899731589
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 899731587}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 58118e25b4d45a54693d251813ca9921, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  board: {fileID: 899731587}
---- !u!65 &899731590
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 899731587}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!33 &899731591
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 899731587}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &898443400
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4640,7 +4347,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 22475538, guid: 751f7137cfffd4a16b1a4c191e687d64, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -33.2
+      value: -40
       objectReference: {fileID: 0}
     - target: {fileID: 22475538, guid: 751f7137cfffd4a16b1a4c191e687d64, type: 3}
       propertyPath: m_SizeDelta.x
@@ -4706,6 +4413,73 @@ MonoBehaviour:
   m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &899731587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 899731588}
+  - component: {fileID: 899731591}
+  - component: {fileID: 899731590}
+  - component: {fileID: 899731589}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &899731588
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899731587}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0.105, y: 0.49, z: 0.037}
+  m_LocalScale: {x: 0.025, y: 2, z: 2}
+  m_Children: []
+  m_Father: {fileID: 286772865}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!114 &899731589
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899731587}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58118e25b4d45a54693d251813ca9921, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  board: {fileID: 899731587}
+--- !u!65 &899731590
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899731587}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &899731591
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899731587}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!4 &901624045 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
@@ -5375,7 +5149,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &961176094
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6277,7 +6051,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1125697710
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6384,11 +6158,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fba2329051a959b43bba66afacb15589, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ownedProperties: []
   pawn: {fileID: 1131218421}
   dice: {fileID: 28973860}
   playerName: 
-  cash: 0
-  ownedProperties: []
 --- !u!114 &1131218421
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6416,7 +6189,7 @@ Transform:
   m_Children:
   - {fileID: 358942523}
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1131218423
 MeshRenderer:
@@ -8442,7 +8215,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 154.5, y: 0}
+  m_AnchoredPosition: {x: 147, y: 0}
   m_SizeDelta: {x: 42.6, y: 35.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1331393015
@@ -10185,6 +9958,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Description text - Dark
       objectReference: {fileID: 0}
+    - target: {fileID: 117092, guid: 576b0985066f948b29da42ea6ff0aedb, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 22474900, guid: 576b0985066f948b29da42ea6ff0aedb, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -11292,6 +11069,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Dog
       objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -11311,10 +11092,6 @@ PrefabInstance:
     - target: {fileID: 400000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 100000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
       propertyPath: m_LocalRotation.x
@@ -11368,8 +11145,8 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: ce810bd45d6fc784996fa3d0c29f6bc5, type: 2}
-    m_RemovedComponents: [{fileID: 9500000, guid: 6f0b8545bc148414dbf8f30bcd357a2c,
-        type: 3}]
+    m_RemovedComponents:
+    - {fileID: 9500000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 6f0b8545bc148414dbf8f30bcd357a2c, type: 3}
 --- !u!1001 &1702627788
 PrefabInstance:
@@ -11987,7 +11764,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 71.3, y: -0.8}
-  m_SizeDelta: {x: 119.4, y: 158}
+  m_SizeDelta: {x: 100, y: 158}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1802155887
 MonoBehaviour:
@@ -12003,7 +11780,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -12530,9 +12307,7 @@ RectTransform:
   - {fileID: 2011132305}
   - {fileID: 2111109478}
   m_Father: {fileID: 0}
-
   m_RootOrder: 19
-
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -12542,7 +12317,6 @@ RectTransform:
 --- !u!4 &1899690497 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 441310253902735158, guid: 1eaa9ba072c40bc479f00bff6f61fcc1,
-
     type: 3}
   m_PrefabInstance: {fileID: 1581635071}
   m_PrefabAsset: {fileID: 0}
@@ -12662,7 +12436,6 @@ PrefabInstance:
 --- !u!224 &1904062472 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 22448376, guid: 5f254271b254145adad88f901e3bc9dc,
-
     type: 3}
   m_PrefabInstance: {fileID: 1904062471}
   m_PrefabAsset: {fileID: 0}
@@ -13960,7 +13733,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -13.499985, y: 0}
+  m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: 42.6, y: 35.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2143444773

--- a/Monopoly/Assets/Scenes/Board.unity
+++ b/Monopoly/Assets/Scenes/Board.unity
@@ -2656,7 +2656,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &580339846
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8207,7 +8207,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1331393014
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11756,7 +11756,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1802155886
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13725,7 +13725,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2143444772
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Monopoly/Assets/Scenes/Board.unity
+++ b/Monopoly/Assets/Scenes/Board.unity
@@ -11790,7 +11790,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 0
+  m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Monopoly/Assets/Scenes/Board.unity
+++ b/Monopoly/Assets/Scenes/Board.unity
@@ -2656,7 +2656,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &580339846
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3378,6 +3378,8 @@ MonoBehaviour:
   shiftRightButton: {fileID: 1331393015}
   finishTurnButton: {fileID: 898443402}
   chosenTextures: []
+  spriteResolved: 0
+  texturesResolved: 0
 --- !u!114 &712514315
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8205,7 +8207,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1331393014
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11754,7 +11756,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1802155886
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11772,7 +11774,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 71.3, y: -0.8}
-  m_SizeDelta: {x: 100, y: 158}
+  m_SizeDelta: {x: 105.3, y: 158}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1802155887
 MonoBehaviour:
@@ -13723,7 +13725,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &2143444772
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13741,7 +13743,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -5, y: 0}
+  m_AnchoredPosition: {x: -4, y: 0}
   m_SizeDelta: {x: 42.6, y: 35.5}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2143444773

--- a/Monopoly/Assets/Scenes/Board.unity
+++ b/Monopoly/Assets/Scenes/Board.unity
@@ -5149,7 +5149,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &961176094
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5448,6 +5448,14 @@ PrefabInstance:
     - target: {fileID: 11421782, guid: 5f254271b254145adad88f901e3bc9dc, type: 3}
       propertyPath: m_FontData.m_Alignment
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 11421782, guid: 5f254271b254145adad88f901e3bc9dc, type: 3}
+      propertyPath: m_FontData.m_VerticalOverflow
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 22295162, guid: 5f254271b254145adad88f901e3bc9dc, type: 3}
+      propertyPath: m_CullTransparentMesh
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5f254271b254145adad88f901e3bc9dc, type: 3}
@@ -6051,7 +6059,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1125697710
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -235,9 +235,6 @@ public class Game : MonoBehaviour
 
     public void finishTurn()
     {
-        gameUIManager.spriteResolved = false;
-        // gameUIManager.texturesResolved = false;
-
         if(!moneyManager.DoesPlayerHasAnyMoneyLeft(currentPlayer))
         {
             HandlePlayerBancrupcy(currentPlayer, players[currentPlayerBeingPaid]);

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -192,6 +192,7 @@ public class Game : MonoBehaviour
                         {
                             currentPlayer.Buy(currentPlayerStandingProperty);
                             currentPlayerStandingProperty.Buy(currentPlayerId);
+                            gameUIManager.texturesResolved = false;
 
                             infoPopup.BoughtPropertyInfo(currentPlayerStandingProperty.propertyName);
                             if (currentPlayerStandingProperty.groupName != PropertyGroupName.station &&
@@ -234,6 +235,9 @@ public class Game : MonoBehaviour
 
     public void finishTurn()
     {
+        gameUIManager.spriteResolved = false;
+        // gameUIManager.texturesResolved = false;
+
         if(!moneyManager.DoesPlayerHasAnyMoneyLeft(currentPlayer))
         {
             HandlePlayerBancrupcy(currentPlayer, players[currentPlayerBeingPaid]);

--- a/Monopoly/Assets/Scripts/UI/DialogMenu.cs
+++ b/Monopoly/Assets/Scripts/UI/DialogMenu.cs
@@ -101,7 +101,7 @@ public class DialogMenu : MonoBehaviour
     }
     public void ShowForRentPayment(Property property, string playerName, int amount)
     {
-        decisionDescription.text = "Płacisz czynsz na rzecz gracza: " + playerName + " w wysokości " + amount + "$";
+        decisionDescription.text = "Płacisz czynsz " + amount + "$" + " graczowi: " + playerName;
        
         dialogCanvasObject.SetActive(true);
         okButton.gameObject.SetActive(true);

--- a/Monopoly/Assets/Scripts/UI/DialogMenu.cs
+++ b/Monopoly/Assets/Scripts/UI/DialogMenu.cs
@@ -102,7 +102,6 @@ public class DialogMenu : MonoBehaviour
     public void ShowForRentPayment(Property property, string playerName, int amount)
     {
         decisionDescription.text = "Płacisz czynsz " + amount + "$" + " graczowi: " + playerName;
-       
         dialogCanvasObject.SetActive(true);
         okButton.gameObject.SetActive(true);
         buyButton.gameObject.SetActive(false);

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -12,7 +12,7 @@ struct PlayerStorage
     public Player player;
 }
 
-public class GameUI : MonoBehaviour, IPointerClickHandler
+public class GameUI : MonoBehaviour
 {
     public Canvas gameUICanvas;
     public Texture[] textures; // wszystkie tekstury pól dodane z poziomu edytora
@@ -94,13 +94,6 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
         shiftRightButton.gameObject.SetActive(true);
         noneTextField.gameObject.SetActive(false);
         switcherEnabled = true;
-    }
-
-    public void OnPointerClick(PointerEventData eventData)
-    {
-        Debug.Log("I'm in OnPointerClick");
-        var currentlyShowedProperty = game.currentPlayer.ownedProperties.FirstOrDefault(x => x.propertyName.ToLower() == chosenTextures[currentTextureIndex].name.ToLower());
-        dialogMenu.ShowForPropertyOwner(currentlyShowedProperty, game.playerExpandedCurrentProperty, game.playerDepositedCurrentProperty, () => { });
     }
 
     private void handleLeftButtonClick()

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -1,5 +1,4 @@
-﻿using UnityEngine.EventSystems;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -61,6 +60,8 @@ public class GameUI : MonoBehaviour
             {
                 currentPlayerStorage.player = game.currentPlayer;
                 texturesResolved = false;
+                spriteResolved = false;
+                currentTextureIndex = 0;
             }
             currentPlayerName.text = game.currentPlayer.playerName;
             currentPlayerCash.text = moneyManager.GetAccountState(currentPlayerName.text).ToString();
@@ -142,7 +143,6 @@ public class GameUI : MonoBehaviour
                     }
                 }
                 texturesResolved = true;
-
                 resolvePlayerCardImage();
             }
         }

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -7,6 +7,11 @@ using TMPro;
 using System;
 using System.Linq;
 
+struct PlayerStorage
+{
+    public Player player;
+}
+
 public class GameUI : MonoBehaviour, IPointerClickHandler
 {
     public Canvas gameUICanvas;
@@ -29,6 +34,10 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
     public List<Texture> chosenTextures;
 
     private bool switcherEnabled = true;
+    public bool spriteResolved = false;
+    public bool texturesResolved = false;
+
+    private PlayerStorage currentPlayerStorage;
 
     // Start is called before the first frame update
     void Start()
@@ -40,6 +49,7 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
         dialogMenu = DialogMenu.Instance();
         game = GameObject.Find("Plane").GetComponent<Game>();
         moneyManager = game.moneyManager;
+        currentPlayerStorage.player = game.players[0];
     }
 
     // Update is called once per frame
@@ -47,6 +57,11 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
     {        
         if (game.currentPlayer)
         {
+            if (game.currentPlayer != currentPlayerStorage.player)
+            {
+                currentPlayerStorage.player = game.currentPlayer;
+                texturesResolved = false;
+            }
             currentPlayerName.text = game.currentPlayer.playerName;
             currentPlayerCash.text = moneyManager.GetAccountState(currentPlayerName.text).ToString();
 
@@ -92,46 +107,51 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
     {
         currentTextureIndex--;
         if (currentTextureIndex < 0) currentTextureIndex = chosenTextures.Count - 1;
+        spriteResolved = false;
         resolvePlayerCardImage();
     }
 
     private void handleRightButtonClick()
     {
         currentTextureIndex++;
+        spriteResolved = false;
         if (currentTextureIndex > chosenTextures.Count - 1) currentTextureIndex = 0;
         resolvePlayerCardImage();
     }
 
     void resolvePlayerCardImage()
     {
-        if (chosenTextures.Count > 0) {
+        if (!spriteResolved && chosenTextures.Count > 0) {
             currentTexture = chosenTextures.ElementAt(currentTextureIndex);
-            cardImage.sprite = Sprite.Create((Texture2D)currentTexture, new Rect(0.0f, 0.0f, currentTexture.width, currentTexture.height), new Vector2(0.0f, 0.0f), 1000.0f);
+            cardImage.sprite = Sprite.Create((Texture2D)currentTexture, new Rect(0.0f, 0.0f, currentTexture.width, currentTexture.height), new Vector2(0.0f, 0.0f), 100.0f);
+            spriteResolved = true;
         }
     }
 
     private void resolveCurrentPlayerTextures()
     {
-        Player currentPlayer;
-        if (game.players != null)
+        if (!texturesResolved)
         {
-            currentPlayer = game.players.Find(x => x.playerName == currentPlayerName.text);
-            // zmapowanie ownedProperties currentPlayera na tekstury z tablicy textures[].
-            // nazwa tekstury jest przechowywana w texture.name (np. Warsaw, jail, chance)
-            
-            chosenTextures = new List<Texture>{ };
-            foreach (Texture texture in textures)
+            Player currentPlayer;
+            if (game.players != null)
             {
-                foreach (Property property in currentPlayer.ownedProperties)
+                currentPlayer = game.players.Find(x => x.playerName == currentPlayerName.text);
+
+                chosenTextures = new List<Texture> { };
+                foreach (Texture texture in textures)
                 {
-                    if (property.propertyName.ToLower() == texture.name.ToLower())
+                    foreach (Property property in currentPlayer.ownedProperties)
                     {
-                        chosenTextures.Add(texture);
+                        if (property.propertyName.ToLower() == texture.name.ToLower())
+                        {
+                            chosenTextures.Add(texture);
+                        }
                     }
                 }
-            }
+                texturesResolved = true;
 
-            resolvePlayerCardImage();
+                resolvePlayerCardImage();
+            }
         }
     }
 }

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -106,7 +106,7 @@ public class GameUI : MonoBehaviour, IPointerClickHandler
     {
         if (chosenTextures.Count > 0) {
             currentTexture = chosenTextures.ElementAt(currentTextureIndex);
-            cardImage.sprite = Sprite.Create((Texture2D)currentTexture, new Rect(0.0f, 0.0f, currentTexture.width, currentTexture.height), new Vector2(0.0f, 0.0f), 100.0f);
+            cardImage.sprite = Sprite.Create((Texture2D)currentTexture, new Rect(0.0f, 0.0f, currentTexture.width, currentTexture.height), new Vector2(0.0f, 0.0f), 1000.0f);
         }
     }
 

--- a/Monopoly/Assets/Scripts/UI/SwitcherImageOnClickDetection.cs
+++ b/Monopoly/Assets/Scripts/UI/SwitcherImageOnClickDetection.cs
@@ -11,8 +11,7 @@ public class SwitcherImageOnClickDetection : MonoBehaviour, IPointerDownHandler
     public Game game;
     private Texture[] textures;
     private int currentTextureIndex;
-
-    // Start is called before the first frame update
+    
     void Start()
     {
         dialogMenu = DialogMenu.Instance();
@@ -21,15 +20,8 @@ public class SwitcherImageOnClickDetection : MonoBehaviour, IPointerDownHandler
         currentTextureIndex = gameUIScript.currentTextureIndex;
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     public void OnPointerDown(PointerEventData eventData)
     {
-        Debug.Log("On pointer click!");
         currentTextureIndex = gameUIScript.currentTextureIndex;
         Property displayedProperty = game.currentPlayer.ownedProperties.ElementAt(currentTextureIndex);
         dialogMenu.ShowForPropertyOwner(displayedProperty, game.playerExpandedCurrentProperty, game.playerDepositedCurrentProperty, ()=> { });

--- a/Monopoly/Assets/Scripts/UI/SwitcherImageOnClickDetection.cs
+++ b/Monopoly/Assets/Scripts/UI/SwitcherImageOnClickDetection.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
-public class SwitcherImageOnClickDetection : MonoBehaviour, IPointerClickHandler
+public class SwitcherImageOnClickDetection : MonoBehaviour, IPointerDownHandler
 {
     GameUI gameUIScript;
     DialogMenu dialogMenu;
@@ -27,8 +27,9 @@ public class SwitcherImageOnClickDetection : MonoBehaviour, IPointerClickHandler
         
     }
 
-    public void OnPointerClick(PointerEventData eventData)
+    public void OnPointerDown(PointerEventData eventData)
     {
+        Debug.Log("On pointer click!");
         currentTextureIndex = gameUIScript.currentTextureIndex;
         Property displayedProperty = game.currentPlayer.ownedProperties.ElementAt(currentTextureIndex);
         dialogMenu.ShowForPropertyOwner(displayedProperty, game.playerExpandedCurrentProperty, game.playerDepositedCurrentProperty, ()=> { });

--- a/Monopoly/ProjectSettings/ProjectVersion.txt
+++ b/Monopoly/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.6f1
+m_EditorVersion: 2018.3.8f1


### PR DESCRIPTION
Istotna PRka zorientowana wokół switchera. Poprawiłem parę detali jak rozmieszczenie przycisku kończącego turę, oprócz tego typu rzeczy najważniejszą zmianą jest praca switchera, do tej pory co klatkę niepotrzebnie pobierał tekstury, tworzył sprity, to powodowało u mnie mocny spadek FPS. Teraz pobranie tekstur, wybranie prawidłowych dla danego gracza, a dalej stworzenie sprita do wyświetlenia to operacje pojedyncze, wykonywane tylko wtedy gdy potrzeba. U mnie na lapku teraz wszystko chodzi płynnie, bez względu na stan switchera :)

Nie działało także kliknięcie na obrazek Property w switcherze, które miało wywoływać okno dialogowe z informacjami o tym Property. Naprawione, brakowało zaznaczenia jednej rzeczy w unity xd Pewnie przestawiło się przy mergu.

Prócz tego poprawiłem też trochę jakość tych obrazków w switcherze, ale jakiegoś mega szału nie ma, więcej z tego chyba nie wycisnę bez ingerencji w pliki .jpg. Wydaje mi się, że skalowanie Unity (bo trzeba dość mocno zmniejszyć te obrazki) trochę słabo działa i dlatego te większe .jpgi wypadają słabiej.