### PR TITLE
Resolving start field related bugs

### DIFF
--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -40,6 +40,7 @@ public class Game : MonoBehaviour
     bool currentPlayerBoughtProperty = false;
     bool currentPlayerIsMakingDecision = false;
     bool fieldHandled = false;
+    bool startMoneyTaken = false;
 
     // Start is called before the first frame update
     void Start()
@@ -89,13 +90,14 @@ public class Game : MonoBehaviour
         {
             if (!players[currentPlayerIndex].IsMoving() && !currentPlayerIsMakingDecision && !infoPopup.active)
             {
-                if (players[currentPlayerIndex].CanMove() )
+                if (players[currentPlayerIndex].CanMove())
                 {
-                players[currentPlayerIndex].AllowRolling();
-                camera.SetDiceCamera();
-                timeLeft = 1.0f;
-                moveFinished = false;
-                currentPlayerBoughtProperty = false;
+                    players[currentPlayerIndex].AllowRolling();
+                    camera.SetDiceCamera();
+                    //timeLeft = 1.0f;
+                    timeLeft = 0.2f;
+                    moveFinished = false;
+                    currentPlayerBoughtProperty = false;
                 }
                 else
                 {
@@ -155,7 +157,6 @@ public class Game : MonoBehaviour
                     break;
                     case PropertyType.chance:
                         PerformChanceAction(DrawAChance());
-                      
                         break;
                     case PropertyType.start:
                         GetStartMoney();
@@ -217,6 +218,7 @@ public class Game : MonoBehaviour
                     players[currentPlayerIndex].SetMoveFinished();
                     currentPlayerIsMakingDecision = false;
                     currentPlayerIndex++;
+                    startMoneyTaken = false;
                 }
                 if (currentPlayerIndex == numberOfPlayers)
                 {
@@ -383,8 +385,12 @@ public class Game : MonoBehaviour
 
     void GetStartMoney()
     {
-        moneyManager.DepositOnAccount(currentPlayer, 200);
-        infoPopup.ShowMessage("Start", "Przechodzisz przez pole start, dostajesz 200$");
+        if (!startMoneyTaken)
+        {
+            moneyManager.DepositOnAccount(currentPlayer, 200);
+            infoPopup.ShowMessage("Start", "Przechodzisz przez pole start, dostajesz 200$");
+            startMoneyTaken = true;
+        }
     }
 
     void SetJail()

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -118,7 +118,7 @@ public class Game : MonoBehaviour
                 timeLeft -= Time.deltaTime;
                 if (timeLeft < 0)
                 {
-                    if(!players[currentPlayerIndex].AllowMovement())
+                    if (!players[currentPlayerIndex].AllowMovement())
                     {
                         GetStartMoney();
                     }
@@ -134,7 +134,7 @@ public class Game : MonoBehaviour
                 int currentPlayerPosition = players[currentPlayerIndex].GetCurrentPosition();
                 currentPlayerId = players[currentPlayerIndex].GetId();
                 currentPlayerStandingProperty = properties[currentPlayerPosition];
-                
+
                 switch (currentPlayerStandingProperty.type)
                 {
                     case PropertyType.forSale:
@@ -153,28 +153,28 @@ public class Game : MonoBehaviour
                         {
                             HandleAbleToBuyProperty(currentPlayerStandingProperty, currentPlayerId);
                         }
-                       
-                    break;
+
+                        break;
                     case PropertyType.chance:
                         PerformChanceAction(DrawAChance());
                         break;
                     case PropertyType.start:
                         GetStartMoney();
-                       
+
                         break;
                     case PropertyType.goToJail:
                         SetJail();
-                     
+
                         break;
                     case PropertyType.parking:
-                        
+
                         break;
                     case PropertyType.jail:
-                      
+
                         break;
                     case PropertyType.tax:
                         PayTax();
-                      
+
                         break;
                 }
                 currentPlayerIsMakingDecision = true;
@@ -210,10 +210,10 @@ public class Game : MonoBehaviour
 
                     }
                     currentPlayerBoughtProperty = false;
-                }   
+                }
             }
 
-            endTurnButtonVisible = (!dialogMenu.dialogCanvasObject.activeSelf && currentPlayer.PawnMoved()) ? true : false;
+            resolveEndTurnButtonStatus();
 
             if (moveFinished)
             {
@@ -228,6 +228,11 @@ public class Game : MonoBehaviour
                 numberOfTurns++;
             }
         }
+    }
+
+    private void resolveEndTurnButtonStatus()
+    {
+        endTurnButtonVisible = (!dialogMenu.dialogCanvasObject.activeSelf && currentPlayer.PawnMoved()) ? true : false;
     }
 
     int calculateNextPlayerIndex(int actualIndex)

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -412,7 +412,7 @@ public class Game : MonoBehaviour
         playerNames.Remove(debtor.playerName);
         debtor.Disable();
         moneyManager.PlayerBancrupcy(debtor);
-        infoPopup.ShowMessage("Banrut", "Gracz " + debtor.playerName + " banrutuje na rzecz " + creditor.playerName);
+        infoPopup.ShowMessage("Bankrut", "Gracz " + debtor.playerName + " bankrutuje na rzecz " + creditor.playerName);
     }
 
     void HandleEndGame()

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -35,6 +35,7 @@ public class Game : MonoBehaviour
     bool gameEnded;
     bool start;
     bool moveFinished = true;
+    public bool endTurnButtonVisible = false;
     float timeLeft;
     int numberOfTurns;
     bool currentPlayerBoughtProperty = false;
@@ -210,21 +211,20 @@ public class Game : MonoBehaviour
 
                     }
                     currentPlayerBoughtProperty = false;
-                    
-                }
+                }   
+            }
 
-                if (moveFinished)
-                {
-                    players[currentPlayerIndex].SetMoveFinished();
-                    currentPlayerIsMakingDecision = false;
-                    currentPlayerIndex++;
-                    startMoneyTaken = false;
-                }
-                if (currentPlayerIndex == numberOfPlayers)
-                {
-                    currentPlayerIndex = 0;
-                    numberOfTurns++;
-                }
+            if (moveFinished)
+            {
+                players[currentPlayerIndex].SetMoveFinished();
+                currentPlayerIsMakingDecision = false;
+                currentPlayerIndex++;
+                startMoneyTaken = false;
+            }
+            if (currentPlayerIndex == numberOfPlayers)
+            {
+                currentPlayerIndex = 0;
+                numberOfTurns++;
             }
         }
     }

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -95,8 +95,7 @@ public class Game : MonoBehaviour
                 {
                     players[currentPlayerIndex].AllowRolling();
                     camera.SetDiceCamera();
-                    //timeLeft = 1.0f;
-                    timeLeft = 0.2f;
+                    timeLeft = 1.0f;
                     moveFinished = false;
                     currentPlayerBoughtProperty = false;
                 }
@@ -213,6 +212,8 @@ public class Game : MonoBehaviour
                     currentPlayerBoughtProperty = false;
                 }   
             }
+
+            endTurnButtonVisible = (!dialogMenu.dialogCanvasObject.activeSelf && currentPlayer.PawnMoved()) ? true : false;
 
             if (moveFinished)
             {

--- a/Monopoly/Assets/Scripts/Game.cs
+++ b/Monopoly/Assets/Scripts/Game.cs
@@ -362,7 +362,7 @@ public class Game : MonoBehaviour
         chanceList.Add(new Chance("Nagroda za znalezienie psa 20$", 20));
         chanceList.Add(new Chance("Nagroda za płacenie podatków na czas 100$", 100));
         chanceList.Add(new Chance("Idziesz do dentysty -koszt 70$", -70));
-        chanceList.Add(new Chance("Kupujesz prezent z okazji dnia matki - 40$", -40));
+        chanceList.Add(new Chance("Kupujesz prezent z okazji Dnia Matki - 40$", -40));
         chanceList.Add(new Chance("Znajdujesz na ulicy banknot 50$", 50));
     }
 

--- a/Monopoly/Assets/Scripts/Player.cs
+++ b/Monopoly/Assets/Scripts/Player.cs
@@ -76,9 +76,12 @@ public class Player : MonoBehaviour
         int destinationFieldIndex = currentFieldIndex + dice.GetRolledValue();
         if (destinationFieldIndex > 40)
         {
-            destinationFieldIndex = destinationFieldIndex - 41;
-            return false;
-
+            destinationFieldIndex -= 41;
+            if (!pawn.IsDestinationReached())
+            {
+                pawn.AllowMovement(destinationFieldIndex);
+            }
+            return false; // bullshit
         }
         if(!pawn.IsDestinationReached())
             pawn.AllowMovement(destinationFieldIndex);

--- a/Monopoly/Assets/Scripts/Player.cs
+++ b/Monopoly/Assets/Scripts/Player.cs
@@ -57,8 +57,8 @@ public class Player : MonoBehaviour
     public void MoveByNumberOfFields(int number)
     {
         currentFieldIndex += number;
-        if (currentFieldIndex > 40)
-            currentFieldIndex = currentFieldIndex - 41;
+        if (currentFieldIndex > 39)
+            currentFieldIndex = currentFieldIndex - 40;
         if (!pawn.IsDestinationReached())
             pawn.AllowMovement(currentFieldIndex);
     }
@@ -74,14 +74,14 @@ public class Player : MonoBehaviour
     public bool AllowMovement()
     {
         int destinationFieldIndex = currentFieldIndex + dice.GetRolledValue();
-        if (destinationFieldIndex > 40)
+        if (destinationFieldIndex > 39)
         {
-            destinationFieldIndex -= 41;
+            destinationFieldIndex -= 40;
             if (!pawn.IsDestinationReached())
             {
                 pawn.AllowMovement(destinationFieldIndex);
             }
-            return false; // bullshit
+            return false;
         }
         if(!pawn.IsDestinationReached())
             pawn.AllowMovement(destinationFieldIndex);
@@ -138,7 +138,7 @@ public class Player : MonoBehaviour
             moving = false;
             diceRolled = false;
             currentFieldIndex = currentFieldIndex + dice.GetRolledValue();
-            if (currentFieldIndex > 40) currentFieldIndex -= 41;
+            if (currentFieldIndex > 39) currentFieldIndex -= 40;
         }
 
 

--- a/Monopoly/Assets/Scripts/Player.cs
+++ b/Monopoly/Assets/Scripts/Player.cs
@@ -138,6 +138,7 @@ public class Player : MonoBehaviour
             moving = false;
             diceRolled = false;
             currentFieldIndex = currentFieldIndex + dice.GetRolledValue();
+            if (currentFieldIndex > 40) currentFieldIndex -= 41;
         }
 
 

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -45,7 +45,7 @@ public class GameUI : MonoBehaviour
         shiftLeftButton.onClick.AddListener(handleLeftButtonClick);
         shiftRightButton.onClick.AddListener(handleRightButtonClick);
         finishTurnButton.onClick.AddListener(game.finishTurn);
-        // finishTurnButton.gameObject.SetActive(false);
+        finishTurnButton.gameObject.SetActive(false);
         dialogMenu = DialogMenu.Instance();
         game = GameObject.Find("Plane").GetComponent<Game>();
         moneyManager = game.moneyManager;
@@ -76,8 +76,8 @@ public class GameUI : MonoBehaviour
             }
         }
         if (game.nextPlayer) nextPlayerName.text = game.nextPlayer.playerName;
-        //if (game.endTurnButtonVisible) finishTurnButton.gameObject.SetActive(true);
-        //    else finishTurnButton.gameObject.SetActive(false);
+        if (game.endTurnButtonVisible) finishTurnButton.gameObject.SetActive(true);
+        else finishTurnButton.gameObject.SetActive(false);
     }
 
     private void disableImageSwitcher()

--- a/Monopoly/Assets/Scripts/UI/GameUI.cs
+++ b/Monopoly/Assets/Scripts/UI/GameUI.cs
@@ -45,6 +45,7 @@ public class GameUI : MonoBehaviour
         shiftLeftButton.onClick.AddListener(handleLeftButtonClick);
         shiftRightButton.onClick.AddListener(handleRightButtonClick);
         finishTurnButton.onClick.AddListener(game.finishTurn);
+        // finishTurnButton.gameObject.SetActive(false);
         dialogMenu = DialogMenu.Instance();
         game = GameObject.Find("Plane").GetComponent<Game>();
         moneyManager = game.moneyManager;
@@ -75,6 +76,8 @@ public class GameUI : MonoBehaviour
             }
         }
         if (game.nextPlayer) nextPlayerName.text = game.nextPlayer.playerName;
+        //if (game.endTurnButtonVisible) finishTurnButton.gameObject.SetActive(true);
+        //    else finishTurnButton.gameObject.SetActive(false);
     }
 
     private void disableImageSwitcher()


### PR DESCRIPTION
Wszystkie bugi związane z polem start powinny być naprawione. Naprawiłem też problemy związane z kończeniem tury, klikanie przycisku "Zakończ turę" w różnych sytuacjach owocowało milionem bugów, teraz przycisk do zakończenia tury pojawia się jedynie w momencie kiedy ruch pionka się zakończył i zakończyliśmy wszystkie akcje w oknie dialogowym, jeśli takie były wymagane. W ten sposób zakończenie tury zawsze jest bezpieczne dla gry i naszego cudownego systemu :)